### PR TITLE
Use Cow for element attribute values

### DIFF
--- a/render/src/simple_element.rs
+++ b/render/src/simple_element.rs
@@ -1,9 +1,10 @@
 use crate::html_escaping::escape_html;
 use crate::Render;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::{Result, Write};
 
-type Attributes<'a> = Option<HashMap<&'a str, &'a str>>;
+type Attributes<'a> = Option<HashMap<&'a str, Cow<'a, str>>>;
 
 /// Simple HTML element tag
 #[derive(Debug)]
@@ -20,7 +21,7 @@ fn write_attributes<'a, W: Write>(maybe_attributes: Attributes<'a>, writer: &mut
         Some(mut attributes) => {
             for (key, value) in attributes.drain() {
                 write!(writer, " {}=\"", key)?;
-                escape_html(value, writer)?;
+                escape_html(&value, writer)?;
                 write!(writer, "\"")?;
             }
             Ok(())

--- a/render_macros/src/element_attributes.rs
+++ b/render_macros/src/element_attributes.rs
@@ -130,13 +130,13 @@ impl<'a> ToTokens for SimpleElementAttributes<'a> {
                     let value = attribute.value_tokens();
 
                     quote! {
-                        hm.insert(#ident, #value);
+                        hm.insert(#ident, ::std::borrow::Cow::from(#value));
                     }
                 })
                 .collect();
 
             let hashmap_declaration = quote! {{
-                let mut hm = std::collections::HashMap::<&str, &str>::new();
+                let mut hm = std::collections::HashMap::<&str, ::std::borrow::Cow<'_, str>>::new();
                 #(#attrs)*
                 Some(hm)
             }};

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -61,6 +61,26 @@ pub fn element_ordering() {
     assert_eq!(deep, "<div><h1>A list</h1><hr/><ul><li>1</li><li>2</li><li>3</li></ul></div>");
 }
 
+#[test]
+fn owned_string() {
+    use pretty_assertions::assert_eq;
+    use render::{component, html, rsx};
+
+    #[component]
+    fn Welcome<'kind, 'name>(kind: &'kind str, name: &'name str) {
+        rsx! {
+            <h1 class={format!("{}-title", kind)}>
+                {format!("Hello, {}", name)}
+            </h1>
+        }
+    }
+
+    assert_eq!(
+        html! { <Welcome kind={"alien"} name={"Yoda"} /> },
+        r#"<h1 class="alien-title">Hello, Yoda</h1>"#
+    );
+}
+
 mod kaki {
     // A simple HTML 5 doctype declaration
     use render::html::HTML5Doctype;


### PR DESCRIPTION
I think this should help with using owned values (e.g. from `format!`) without requiring unnecessary clones