### PR TITLE
Prepare for running in stable Rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: hecrj/setup-rust-action@v1
       with:
-        rust-version: nightly
+        rust-version: beta
     - uses: actions/checkout@v1
     - name: Build
       run: cargo build --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,21 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +122,40 @@ version = "0.3.1"
 dependencies = [
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "render 0.3.1",
+ "trybuild 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -127,6 +176,35 @@ dependencies = [
  "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "trybuild"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -154,6 +232,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,16 +248,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ctor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3e061727ebef83bbccac7c27b9a5ff9fd83094d34cb20f4005440a9562a27de7"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+"checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum itoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+"checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro-error 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
 "checksum proc-macro-error-attr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 "checksum proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum ryu 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+"checksum serde 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "c9124df5b40cbd380080b2cc6ab894c040a3070d995f5c9dc77e18c34a8ae37d"
+"checksum serde_derive 1.0.111 (registry+https://github.com/rust-lang/crates.io-index)" = "3f2c3ac8e6ca1e9c80b8be1023940162bf81ae3cffbb1809474152f2ce1eb250"
+"checksum serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "ec2c5d7e739bc07a3e73381a39d61fdb5f671c60c1df26a130690665803d8226"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
+"checksum termcolor 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+"checksum toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
+"checksum trybuild 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "39e3183158b2c8170db33b8b3a90ddc7b5f380d15b50794d22c1fa9c61b47249"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-error-attr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,6 +94,7 @@ name = "render_macros"
 version = "0.3.1"
 dependencies = [
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "render 0.3.1",
@@ -95,8 +120,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-mid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -124,10 +164,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
+"checksum proc-macro-error 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98e9e4b82e0ef281812565ea4751049f1bdcdfccda7d3f459f2e138a40c08678"
+"checksum proc-macro-error-attr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4f5444ead4e9935abd7f27dc51f7e852a0569ac888096d5ec2499470794e2e53"
 "checksum proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum syn-mid 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7be3539f6c128a931cf19dcee741c1af532c7fd387baa739c03dd2e96479338a"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/README.md
+++ b/README.md
@@ -34,22 +34,12 @@ ergonomics or speed.
 
 ## Usage
 
-> Note: `render` needs the `nightly` Rust compiler, for now, so it will have hygienic macros.
-
-This means you will need to add the following feature flag in the root of your `lib.rs`/`main.rs`:
-
-```rust
-#![feature(proc_macro_hygiene)]
-```
-
 ### Simple HTML rendering
 
 In order to render a simple HTML fragment into a `String`, use the `rsx!` macro to generate a
 component tree, and call `render` on it:
 
 ```rust
-#![feature(proc_macro_hygiene)]
-
 use render::{rsx, Render};
 
 let tree = rsx! {
@@ -72,8 +62,6 @@ use un-escaped values so you can dangerously insert raw HTML, use the `raw!` mac
 string:
 
 ```rust
-#![feature(proc_macro_hygiene)]
-
 use render::{html, raw};
 
 let tree = html! {
@@ -95,8 +83,6 @@ In order to build up components from other components or HTML nodes, you can use
 macro, which generates a `Render` component tree:
 
 ```rust
-#![feature(proc_macro_hygiene)]
-
 use render::{component, rsx, html};
 
 #[component]
@@ -148,8 +134,6 @@ your libraries.
 #### Full example
 
 ```rust
-#![feature(proc_macro_hygiene)]
-
 // A simple HTML 5 doctype declaration
 use render::html::HTML5Doctype;
 use render::{

--- a/render/src/fragment.rs
+++ b/render/src/fragment.rs
@@ -7,7 +7,6 @@ use std::fmt::{Result, Write};
 /// in a RSX fashion
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use pretty_assertions::assert_eq;
 /// # use render_macros::html;
 /// let result = html! {

--- a/render/src/html.rs
+++ b/render/src/html.rs
@@ -6,7 +6,6 @@ use std::fmt::{Result, Write};
 /// HTML 5 doctype declaration
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use pretty_assertions::assert_eq;
 /// # use render::html::HTML5Doctype;
 /// # use render::html;

--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -32,21 +32,12 @@
 //!
 //! # Usage
 //!
-//! > Note: `render` needs the `nightly` Rust compiler, for now, so it will have hygienic macros.
-//!
-//! This means you will need to add the following feature flag in the root of your `lib.rs`/`main.rs`:
-//!
-//! ```rust
-//! #![feature(proc_macro_hygiene)]
-//! ```
-//!
 //! ## Simple HTML rendering
 //!
 //! In order to render a simple HTML fragment into a `String`, use the `rsx!` macro to generate a
 //! component tree, and call `render` on it:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene)]
 //! # use pretty_assertions::assert_eq;
 //!
 //! use render::{rsx, Render};
@@ -71,7 +62,6 @@
 //! string:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene)]
 //! # use pretty_assertions::assert_eq;
 //!
 //! use render::{html, raw};
@@ -95,7 +85,6 @@
 //! macro, which generates a `Render` component tree:
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene)]
 //! # use pretty_assertions::assert_eq;
 //!
 //! use render::{component, rsx, html};
@@ -122,8 +111,6 @@
 //! ### Full example
 //!
 //! ```rust
-//! #![feature(proc_macro_hygiene)]
-//!
 //! // A simple HTML 5 doctype declaration
 //! use render::html::HTML5Doctype;
 //! use render::{
@@ -176,8 +163,6 @@
 //! # );
 //! # assert_eq!(actual, expected);
 //! ```
-
-#![feature(proc_macro_hygiene)]
 
 pub mod fragment;
 pub mod html;

--- a/render_macros/Cargo.toml
+++ b/render_macros/Cargo.toml
@@ -19,6 +19,7 @@ proc-macro = true
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+proc-macro-error = "1.0"
 
 [dev-dependencies]
 render = { path = "../render", version = "0.3" }

--- a/render_macros/src/element_attributes.rs
+++ b/render_macros/src/element_attributes.rs
@@ -61,11 +61,11 @@ impl Parse for ElementAttributes {
             let attribute = input.parse::<ElementAttribute>()?;
             let ident = attribute.ident();
             if attributes.contains(&attribute) {
-                let error_message = format!(
+                emit_error!(
+                    ident.span(),
                     "There is a previous definition of the {} attribute",
                     quote!(#ident)
                 );
-                emit_error!(ident.span(), "{}", error_message);
             }
             attributes.insert(attribute);
         }

--- a/render_macros/src/element_attributes.rs
+++ b/render_macros/src/element_attributes.rs
@@ -1,5 +1,6 @@
 use crate::children::Children;
 use crate::element_attribute::ElementAttribute;
+use proc_macro_error::emit_error;
 use quote::{quote, ToTokens};
 use std::collections::HashSet;
 use syn::ext::IdentExt;
@@ -43,7 +44,7 @@ impl ElementAttributes {
             .filter_map(|attribute| match attribute.validate(is_custom_element) {
                 Ok(x) => Some(x),
                 Err(err) => {
-                    err.span().unwrap().error(err.to_string()).emit();
+                    emit_error!(err.span(), "Invalid attribute: {}", err);
                     None
                 }
             })
@@ -64,7 +65,7 @@ impl Parse for ElementAttributes {
                     "There is a previous definition of the {} attribute",
                     quote!(#ident)
                 );
-                ident.span().unwrap().warning(error_message).emit();
+                emit_error!(ident.span(), "{}", error_message);
             }
             attributes.insert(attribute);
         }

--- a/render_macros/src/function_component.rs
+++ b/render_macros/src/function_component.rs
@@ -1,4 +1,5 @@
 use proc_macro::TokenStream;
+use proc_macro_error::emit_error;
 use quote::quote;
 use syn::spanned::Spanned;
 
@@ -25,7 +26,7 @@ pub fn create_function_component(f: syn::ItemFn) -> TokenStream {
             .filter_map(|argument| match argument {
                 syn::FnArg::Typed(typed) => Some(typed),
                 syn::FnArg::Receiver(rec) => {
-                    rec.span().unwrap().error("Don't use `self` on components");
+                    emit_error!(rec.span(), "Don't use `self` on components");
                     None
                 }
             })

--- a/render_macros/src/lib.rs
+++ b/render_macros/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_diagnostic)]
-
 extern crate proc_macro;
 
 mod child;
@@ -12,6 +10,7 @@ mod tags;
 
 use element::Element;
 use proc_macro::TokenStream;
+use proc_macro_error::proc_macro_error;
 use quote::quote;
 use syn::parse_macro_input;
 
@@ -22,7 +21,6 @@ use syn::parse_macro_input;
 /// ### Simple HTML elements start with a lowercase
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use pretty_assertions::assert_eq;
 /// # use render_macros::html;
 /// let rendered = html! { <div id={"main"}>{"Hello"}</div> };
@@ -32,7 +30,6 @@ use syn::parse_macro_input;
 /// ### Custom components start with an uppercase
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use pretty_assertions::assert_eq;
 /// # use render_macros::{html, rsx};
 /// use render::Render;
@@ -54,7 +51,6 @@ use syn::parse_macro_input;
 /// ### Values are always surrounded by curly braces
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use render_macros::html;
 /// # use pretty_assertions::assert_eq;
 /// let rendered = html! {
@@ -67,7 +63,6 @@ use syn::parse_macro_input;
 /// ### HTML entities can accept dashed-separated value
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use render_macros::html;
 /// # use pretty_assertions::assert_eq;
 /// let rendered = html! {
@@ -80,7 +75,6 @@ use syn::parse_macro_input;
 /// ### Custom components can't accept dashed-separated values
 ///
 /// ```compile_fail
-/// # #![feature(proc_macro_hygiene)]
 /// # use render_macros::html;
 /// // This will fail the compilation:
 /// let rendered = html! {
@@ -93,7 +87,6 @@ use syn::parse_macro_input;
 /// `value={value}` like Rust's punning
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use render_macros::html;
 /// # use pretty_assertions::assert_eq;
 /// let class = "someclass";
@@ -108,7 +101,6 @@ use syn::parse_macro_input;
 /// ### Punning is not supported for dashed-delimited attributes
 ///
 /// ```compile_fail
-/// # #![feature(proc_macro_hygiene)]
 /// # use render_macros::html;
 ///
 /// let rendered = html! {
@@ -118,6 +110,7 @@ use syn::parse_macro_input;
 /// assert_eq!(rendered, r#"<div class="some_class"/>"#);
 /// ```
 #[proc_macro]
+#[proc_macro_error]
 pub fn html(input: TokenStream) -> TokenStream {
     let el = proc_macro2::TokenStream::from(rsx(input));
     let result = quote! { ::render::Render::render(#el) };
@@ -126,6 +119,7 @@ pub fn html(input: TokenStream) -> TokenStream {
 
 /// Generate a renderable component tree, before rendering it
 #[proc_macro]
+#[proc_macro_error]
 pub fn rsx(input: TokenStream) -> TokenStream {
     let el = parse_macro_input!(input as Element);
     let result = quote! { #el };
@@ -139,7 +133,6 @@ pub fn rsx(input: TokenStream) -> TokenStream {
 /// [`String`](std::string::String):
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use render_macros::{component, rsx};
 /// #
 /// #[component]
@@ -151,7 +144,6 @@ pub fn rsx(input: TokenStream) -> TokenStream {
 /// Practically, this is exactly the same as using the [Render](../render/trait.Render.html) trait:
 ///
 /// ```rust
-/// # #![feature(proc_macro_hygiene)]
 /// # use render_macros::{component, rsx, html};
 /// # use render::Render;
 /// # use pretty_assertions::assert_eq;
@@ -181,6 +173,7 @@ pub fn rsx(input: TokenStream) -> TokenStream {
 /// # assert_eq!(from_fn, from_struct);
 /// ```
 #[proc_macro_attribute]
+#[proc_macro_error]
 pub fn component(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let f = parse_macro_input!(item as syn::ItemFn);
     function_component::create_function_component(f)

--- a/render_macros/src/tags.rs
+++ b/render_macros/src/tags.rs
@@ -1,5 +1,5 @@
 use crate::element_attributes::ElementAttributes;
-use proc_macro_error::emit_error;
+use proc_macro_error::abort;
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
@@ -56,7 +56,7 @@ impl ClosingTag {
         let self_path = &self.name;
         let self_path_str = quote!(#self_path).to_string();
         if self_path_str != open_tag_path_str {
-            emit_error!(
+            abort!(
                 self.name.span(),
                 "Expected closing tag for: <{}>",
                 &open_tag_path_str

--- a/render_macros/src/tags.rs
+++ b/render_macros/src/tags.rs
@@ -56,8 +56,11 @@ impl ClosingTag {
         let self_path = &self.name;
         let self_path_str = quote!(#self_path).to_string();
         if self_path_str != open_tag_path_str {
-            let error_message = format!("Expected closing tag for: <{}>", &open_tag_path_str);
-            emit_error!(self.name.span(), "{}", error_message);
+            emit_error!(
+                self.name.span(),
+                "Expected closing tag for: <{}>",
+                &open_tag_path_str
+            );
         }
     }
 }

--- a/render_macros/src/tags.rs
+++ b/render_macros/src/tags.rs
@@ -1,4 +1,5 @@
 use crate::element_attributes::ElementAttributes;
+use proc_macro_error::emit_error;
 use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
@@ -56,7 +57,7 @@ impl ClosingTag {
         let self_path_str = quote!(#self_path).to_string();
         if self_path_str != open_tag_path_str {
             let error_message = format!("Expected closing tag for: <{}>", &open_tag_path_str);
-            self.name.span().unwrap().error(error_message).emit();
+            emit_error!(self.name.span(), "{}", error_message);
         }
     }
 }

--- a/render_tests/Cargo.toml
+++ b/render_tests/Cargo.toml
@@ -13,4 +13,4 @@ render = { path = "../render" }
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-
+trybuild = "1.0"

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -1,4 +1,10 @@
 #[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("ui/fail/*.rs");
+}
+
+#[test]
 pub fn works_with_dashes() {
     use pretty_assertions::assert_eq;
 

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(proc_macro_hygiene)]
-
 #[test]
 pub fn works_with_dashes() {
     use pretty_assertions::assert_eq;

--- a/render_tests/ui/fail/unclosed-tag-complex.rs
+++ b/render_tests/ui/fail/unclosed-tag-complex.rs
@@ -1,0 +1,14 @@
+use render::html;
+
+fn main() {
+    html! {
+      <div>
+        <h1>{"A list"}</h1>
+        <hr />
+        <ul>
+          <li>{"1"}</li>
+          <li>
+        </ul>
+      </div>
+    };
+}

--- a/render_tests/ui/fail/unclosed-tag-complex.stderr
+++ b/render_tests/ui/fail/unclosed-tag-complex.stderr
@@ -1,39 +1,5 @@
-error: expected one of `)`, `,`, `.`, `?`, or an operator, found `compile_error`
-  --> $DIR/unclosed-tag-complex.rs:12:9
-   |
-11 |         </ul>
-   |             -
-   |             |
-   |             expected one of `)`, `,`, `.`, `?`, or an operator
-   |             help: missing `,`
-12 |       </div>
-   |         ^^^ unexpected token
-
 error: Expected closing tag for: <li>
   --> $DIR/unclosed-tag-complex.rs:11:11
    |
 11 |         </ul>
    |           ^^
-
-error: Expected closing tag for: <ul>
-  --> $DIR/unclosed-tag-complex.rs:12:9
-   |
-12 |       </div>
-   |         ^^^
-
-error[E0061]: this function takes 1 argument but 2 arguments were supplied
-  --> $DIR/unclosed-tag-complex.rs:4:5
-   |
-4  | /     html! {
-5  | |       <div>
-6  | |         <h1>{"A list"}</h1>
-7  | |         <hr />
-...  |
-11 | |         </ul>
-   | |           --
-12 | |       </div>
-   | |         --- supplied 2 arguments
-13 | |     };
-   | |______^ expected 1 argument
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/render_tests/ui/fail/unclosed-tag-complex.stderr
+++ b/render_tests/ui/fail/unclosed-tag-complex.stderr
@@ -1,0 +1,39 @@
+error: expected one of `)`, `,`, `.`, `?`, or an operator, found `compile_error`
+  --> $DIR/unclosed-tag-complex.rs:12:9
+   |
+11 |         </ul>
+   |             -
+   |             |
+   |             expected one of `)`, `,`, `.`, `?`, or an operator
+   |             help: missing `,`
+12 |       </div>
+   |         ^^^ unexpected token
+
+error: Expected closing tag for: <li>
+  --> $DIR/unclosed-tag-complex.rs:11:11
+   |
+11 |         </ul>
+   |           ^^
+
+error: Expected closing tag for: <ul>
+  --> $DIR/unclosed-tag-complex.rs:12:9
+   |
+12 |       </div>
+   |         ^^^
+
+error[E0061]: this function takes 1 argument but 2 arguments were supplied
+  --> $DIR/unclosed-tag-complex.rs:4:5
+   |
+4  | /     html! {
+5  | |       <div>
+6  | |         <h1>{"A list"}</h1>
+7  | |         <hr />
+...  |
+11 | |         </ul>
+   | |           --
+12 | |       </div>
+   | |         --- supplied 2 arguments
+13 | |     };
+   | |______^ expected 1 argument
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/render_tests/ui/fail/unclosed-tag.rs
+++ b/render_tests/ui/fail/unclosed-tag.rs
@@ -1,0 +1,9 @@
+use render::html;
+
+fn main() {
+    html! {
+      <ul>
+        <li>
+      </ul>
+    };
+}

--- a/render_tests/ui/fail/unclosed-tag.stderr
+++ b/render_tests/ui/fail/unclosed-tag.stderr
@@ -1,0 +1,5 @@
+error: Expected closing tag for: <li>
+ --> $DIR/unclosed-tag.rs:7:9
+  |
+7 |       </ul>
+  |         ^^

--- a/render_tests/ui/fail/unexpected-attribute.rs
+++ b/render_tests/ui/fail/unexpected-attribute.rs
@@ -1,0 +1,10 @@
+use render::{component, html, rsx};
+
+#[component]
+fn Heading<'title>(title: &'title str) {
+    rsx! { <h1>{title}</h1> }
+}
+
+fn main() {
+    html! { <Heading t={"Hello world!"} /> };
+}

--- a/render_tests/ui/fail/unexpected-attribute.stderr
+++ b/render_tests/ui/fail/unexpected-attribute.stderr
@@ -1,0 +1,7 @@
+error[E0560]: struct `Heading<'_>` has no field named `t`
+ --> $DIR/unexpected-attribute.rs:9:22
+  |
+9 |     html! { <Heading t={"Hello world!"} /> };
+  |                      ^ `Heading<'_>` does not have this field
+  |
+  = note: available fields are: `title`


### PR DESCRIPTION
Stable is getting `proc_macro_hygiene` soon! It's already in beta. Unfortunately it doesn't have `proc_macro_diagnostic`, but fortunately [proc-macro-error](https://crates.io/crates/proc-macro-error) provides a way to handle this, albeit in a possibly degraded way. Still, being able to use this crate on stable is a huge benefit.

This change makes the tests pass on beta!