### PR TITLE
Add Render impls for numeric primitives

### DIFF
--- a/render/src/lib.rs
+++ b/render/src/lib.rs
@@ -167,6 +167,7 @@
 pub mod fragment;
 pub mod html;
 pub mod html_escaping;
+mod numbers;
 mod render;
 mod simple_element;
 mod text_element;

--- a/render/src/numbers.rs
+++ b/render/src/numbers.rs
@@ -1,0 +1,29 @@
+//! Render impls for numeric primitives
+
+use crate::Render;
+use std::fmt::{Result, Write};
+
+macro_rules! simple_render_impl {
+    ($t:ty) => {
+        impl Render for $t {
+            fn render_into<W: Write>(self, writer: &mut W) -> Result {
+                write!(writer, "{}", self)
+            }
+        }
+    };
+}
+
+simple_render_impl!(f32);
+simple_render_impl!(f64);
+simple_render_impl!(i128);
+simple_render_impl!(i16);
+simple_render_impl!(i32);
+simple_render_impl!(i64);
+simple_render_impl!(i8);
+simple_render_impl!(isize);
+simple_render_impl!(u128);
+simple_render_impl!(u16);
+simple_render_impl!(u32);
+simple_render_impl!(u64);
+simple_render_impl!(u8);
+simple_render_impl!(usize);

--- a/render_tests/src/lib.rs
+++ b/render_tests/src/lib.rs
@@ -118,6 +118,16 @@ fn owned_string() {
     );
 }
 
+#[test]
+fn number() {
+    use pretty_assertions::assert_eq;
+    use render::html;
+
+    let num = 42;
+
+    assert_eq!(html! { <p>{num}</p> }, "<p>42</p>")
+}
+
 mod kaki {
     // A simple HTML 5 doctype declaration
     use render::html::HTML5Doctype;


### PR DESCRIPTION
As far as I know, numbers wouldn't need to be escaped, but I could be wrong